### PR TITLE
Add a template for prototype work summaries

### DIFF
--- a/results/_template.md
+++ b/results/_template.md
@@ -1,0 +1,63 @@
+# XYZ Prototype Summary
+
+<!--- This overall description fits for every prototype technology --->
+This summary belongs to prototyping work on evaluating technology candidates to be used for a new implementation of the Eclipse Standard Widget Toolkit (SWT) layer which is (as far as possible) independent from the operating system. In comparison to the existing SWT implementations that use OS libraries and widgets, a technology for a potential new implementation should already deal with and hide OS specifics, such that an SWT implementation does not have to care about the underlying OS anymore. To this end, the technology must be capable of providing the same features as the union of the existing SWT implementations. In addition, it should be an enabler for further improvement, such as better customizing and theming options, better web integration via web assembly, sophisticated multi-monitor HiDPI support and the like.
+
+The goal of the prototyping phase is not to completely implement the SWT layer with a specific technology, but to provide insights about whether such an implementation is feasible and reasonable. This includes a founded estimation whether or with how much effort this will be possible technology-wise, which developer capabilities are required for development and maintenance, and for what kind of improvements the technology might be an enabler. The results should serve as a means to make an educated decision on whether one or multiple technologies are suitable for an actual implementation of SWT using those technologies and, in case multiple fit, which of them fits best.
+
+
+## Technology
+
+<!-- Overview of the technology/technologies involved in the prototype, why they were selected and which details are important for using the technology -->
+
+### Reasons
+
+<!-- What were the reasons for considering this technology/technologies? That may not only include the overall technology like Gtk but also reasons for choosing a specific port for another OS or the like. And that may go beyond why we initially chose to develop a prototype based on the technology: did you find further benefits during the prototyping work that serve as reasons for choosing the technology? -->
+
+### Details
+
+<!-- What are important details of the according technology/technologies? How do they work in a nutshell, who maintains ports to other operating systems etc.? -->
+
+### Required Skills
+
+<!-- What specific skills are required for adopting the technology, e.g., do you require specific programming (language) skills like C/C++? When are they required, e.g., only for setting something up one, or frequently for fixing bugs, debugging etc.? -->
+
+
+## Contributors
+
+<!-- List the people that have worked on the prototype, in order to (1) acknowledge their work and (2) document whom one might ask to get further information about the prototyping work now or later. Please also give an estimation of the time invest (like person months) to get an impression of how complicated it was to achieve the presented results. -->
+
+Prototyping work has been conducted by:
+- ...
+
+Total time invest was about ...
+
+
+## Results
+
+<!-- A summary of the results of the prototyping work, including what went well and what did not go well, which artifacts and insights you produces, and which risks you identified for using the technology for a new Eclipse SWT implementation. Please also refer to other sources of information, such as code you developed or documentation you wrote. -->
+
+### Achievements
+
+<!-- What did you achieve in terms of concrete prototyping work? That may include code, documentation and other artifacts. What features/functionality can you show with these artifacts? Which milestones did not reach and what functionality artifacts and document did you gain when developing the prototype? -->
+
+
+### Insights
+
+<!-- What insights did you gain when developing the prototype? What were the central obstacles that might also influence a complete SWT implementation based on that technology? What was complicated to achieve? What did take long? -->
+
+### Risks
+
+<!-- What are risks / unknown points when trying to develop an actual SWT implementation based on this technology? -->
+
+
+## Conclusion
+
+<!-- A summarizing statement, based on the previous insights, assessing whether or how far the technology is a suitable candidate for a new Eclipse SWT implementation -->
+
+**Final Assessment:** <!-- Closing assessment statement in one or two sentences-->
+
+
+## Appendix
+
+<!-- (Optional) Additional material, like screenshots of the prototype or the like -->


### PR DESCRIPTION
This adds a template for writing a summary in a prototype of the initiative, based on the initial one provided for Skia/VCL: https://github.com/swt-initiative31/documents/blob/main/results/skia_vcl.md